### PR TITLE
Subtype AbstractBridgeOptimizer

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1,51 +1,44 @@
 struct Reformulation <: MOI.AbstractOptimizerAttribute end
 
-struct Optimizer{O<:MOI.ModelLike} <: MOI.AbstractOptimizer
-    optimizer::O
+struct Bridges
+end
+
+Base.isempty(::Bridges) = true
+MOI.Bridges.Constraint.has_bridges(::Bridges) = false
+
+struct Optimizer{O<:MOI.ModelLike} <: MOI.Bridges.AbstractBridgeOptimizer
+    model::O # This need to be called `model` by convention of `AbstractBridgeOptimizer`
     reformulation::AbstractComplementarityRelaxation
-    function Optimizer(optimizer::MOI.ModelLike)
-        return new{typeof(optimizer)}(optimizer, ScholtesRelaxation(0.0))
+    constraint_map::MOI.Bridges.Constraint.Map
+    con_to_name::Dict{MOI.ConstraintIndex,String}
+    name_to_con::Union{Dict{String,MOI.ConstraintIndex},Nothing}
+    function Optimizer(model::MOI.ModelLike)
+        return new{typeof(model)}(
+            model,
+            ScholtesRelaxation(0.0),
+            MOI.Bridges.Constraint.Map(),
+        )
     end
 end
 
-MOI.is_empty(model::Optimizer) = MOI.is_empty(model.optimizer)
-MOI.empty!(model::Optimizer) = MOI.empty!(model.optimizer)
+MOI.Bridges.Constraint.bridges(model::Optimizer) = model.constraint_map
 
-function MOI.supports(
-    model::Optimizer,
-    attr::Union{MOI.AbstractModelAttribute,MOI.AbstractOptimizerAttribute},
-)
-    return MOI.supports(model.optimizer, attr)
+# No variable bridge
+MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractSet}) = false
+
+# No objective bridge
+MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractFunction}) = false
+
+# We only bridge complements constraints
+MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI.AbstractSet}) = false
+MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractVectorFunction}, ::Type{<:MOI.Complements}) = true
+MOI.Bridges.supports_bridging_constraint(::Optimizer, ::Type{<:MOI.AbstractVectorFunction}, ::Type{<:MOI.Complements}) = true
+MOI.Bridges.bridge_type(::Optimizer, ::Type{<:MOI.AbstractVectorFunction}, ::Type{<:MOI.Complements}) = VerticalBridge
+MOI.Bridges.bridge_type(model::Optimizer, ::Type{<:MOI.VectorOfVariables}, ::Type{<:MOI.Complements}) = NonlinearBridge{model.reformulation}
+
+function MOI.Bridges.bridging_cost(b::Optimizer, args...)
+    return MOI.Bridges.bridging_cost(MOI.Bridges.bridge_type(b, args...))
 end
 
-function MOI.get(
-    model::Optimizer,
-    attr::Union{MOI.AbstractModelAttribute,MOI.AbstractOptimizerAttribute},
-)
-    return MOI.get(model.optimizer, attr)
-end
-
-function MOI.set(
-    model::Optimizer,
-    attr::Union{MOI.AbstractModelAttribute,MOI.AbstractOptimizerAttribute},
-    value,
-)
-    return MOI.set(model.optimizer, attr, value)
-end
-
-function MOI.supports_constraint(
-    model::Optimizer,
-    ::Type{F},
-    ::Type{S},
-) where {F<:MOI.AbstractFunction,S<:MOI.AbstractSet}
-    return MOI.supports_constraint(model.optimizer, F, S)
-end
-
-function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
-    tmp = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
-    tmp_index_map = MOI.copy_to(tmp, src)
-    reformulate_to_vertical!(tmp)
-    reformulate_as_nonlinear_program!(tmp, dest.reformulation)
-    # TODO combine with `tmp_index_map`
-    return MOI.copy_to(dest.optimizer, tmp)
-end
+# We may have a chain of bridges
+MOI.Bridges.recursive_model(b::Optimizer) = b

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1,11 +1,5 @@
 struct Reformulation <: MOI.AbstractOptimizerAttribute end
 
-struct Bridges
-end
-
-Base.isempty(::Bridges) = true
-MOI.Bridges.Constraint.has_bridges(::Bridges) = false
-
 struct Optimizer{O<:MOI.ModelLike} <: MOI.Bridges.AbstractBridgeOptimizer
     model::O # This need to be called `model` by convention of `AbstractBridgeOptimizer`
     reformulation::AbstractComplementarityRelaxation
@@ -30,15 +24,35 @@ MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractSet}) = false
 MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractFunction}) = false
 
 # We only bridge complements constraints
-MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI.AbstractSet}) = false
-MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractVectorFunction}, ::Type{<:MOI.Complements}) = true
-MOI.Bridges.supports_bridging_constraint(::Optimizer, ::Type{<:MOI.AbstractVectorFunction}, ::Type{<:MOI.Complements}) = true
-MOI.Bridges.bridge_type(::Optimizer, ::Type{<:MOI.AbstractVectorFunction}, ::Type{<:MOI.Complements}) = VerticalBridge
+MOI.Bridges.is_bridged(
+    ::Optimizer,
+    ::Type{<:MOI.AbstractFunction},
+    ::Type{<:MOI.AbstractSet},
+) = false
+MOI.Bridges.is_bridged(
+    ::Optimizer,
+    ::Type{<:MOI.AbstractVectorFunction},
+    ::Type{<:MOI.Complements},
+) = true
+MOI.Bridges.supports_bridging_constraint(
+    ::Optimizer,
+    ::Type{<:MOI.AbstractVectorFunction},
+    ::Type{<:MOI.Complements},
+) = true
+MOI.Bridges.bridge_type(
+    ::Optimizer,
+    ::Type{<:MOI.AbstractVectorFunction},
+    ::Type{<:MOI.Complements},
+) = VerticalBridge
 
 # It's a bit unfortunate that we're passing the reformulation as type parameter.
 # This means that if the user change the **value** of the tolerance in the reformulation
 # then it will trigger a recompilation of the bridge.
-MOI.Bridges.bridge_type(model::Optimizer, ::Type{<:MOI.VectorOfVariables}, ::Type{<:MOI.Complements}) = NonlinearBridge{model.reformulation}
+MOI.Bridges.bridge_type(
+    model::Optimizer,
+    ::Type{<:MOI.VectorOfVariables},
+    ::Type{<:MOI.Complements},
+) = NonlinearBridge{model.reformulation}
 
 function MOI.Bridges.bridging_cost(b::Optimizer, args...)
     return MOI.Bridges.bridging_cost(MOI.Bridges.bridge_type(b, args...))

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -34,6 +34,10 @@ MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI
 MOI.Bridges.is_bridged(::Optimizer, ::Type{<:MOI.AbstractVectorFunction}, ::Type{<:MOI.Complements}) = true
 MOI.Bridges.supports_bridging_constraint(::Optimizer, ::Type{<:MOI.AbstractVectorFunction}, ::Type{<:MOI.Complements}) = true
 MOI.Bridges.bridge_type(::Optimizer, ::Type{<:MOI.AbstractVectorFunction}, ::Type{<:MOI.Complements}) = VerticalBridge
+
+# It's a bit unfortunate that we're passing the reformulation as type parameter.
+# This means that if the user change the **value** of the tolerance in the reformulation
+# then it will trigger a recompilation of the bridge.
 MOI.Bridges.bridge_type(model::Optimizer, ::Type{<:MOI.VectorOfVariables}, ::Type{<:MOI.Complements}) = NonlinearBridge{model.reformulation}
 
 function MOI.Bridges.bridging_cost(b::Optimizer, args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,10 +68,7 @@ function test_nonlinear_expr()
     MOI.Utilities.attach_optimizer(model)
 
     expected = nonlinear_test_reformulated_model()
-    MOI.Bridges._test_structural_identical(
-        unsafe_backend(model).model,
-        backend(expected),
-    )
+    MOI.Bridges._test_structural_identical(unsafe_backend(model).model, backend(expected))
 end
 
 instances = filter(names(Instances; all = true)) do name

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,12 +51,11 @@ function test_model(model_func)
     inner = MOI.Utilities.Model{Float64}()
     set_optimizer(model, () -> ComplementOpt.Optimizer(inner))
     MOI.Utilities.attach_optimizer(model)
-    MOI.Utilities.attach_optimizer(backend(model).optimizer.model)
     if haskey(expected_models, model_func)
         expected_func = expected_models[model_func]
         expected = expected_func()
         MOI.Bridges._test_structural_identical(
-            unsafe_backend(model).optimizer,
+            unsafe_backend(model).model,
             backend(expected),
         )
     end
@@ -67,11 +66,10 @@ function test_nonlinear_expr()
     inner = MOI.Utilities.Model{Float64}()
     set_optimizer(model, () -> ComplementOpt.Optimizer(inner))
     MOI.Utilities.attach_optimizer(model)
-    MOI.Utilities.attach_optimizer(backend(model).optimizer.model)
 
     expected = nonlinear_test_reformulated_model()
     MOI.Bridges._test_structural_identical(
-        unsafe_backend(model).optimizer,
+        unsafe_backend(model).model,
         backend(expected),
     )
 end
@@ -97,10 +95,8 @@ end
     ComplementOpt.KanzowSchwarzRelaxation(1e-8),
 ]
     model = Instances.fletcher_leyffer_ex1_model()
-    ind_cc1, ind_cc2 = ComplementOpt.reformulate_to_vertical!(JuMP.backend(model))
-    ComplementOpt.reformulate_as_nonlinear_program!(JuMP.backend(model), relax)
 
-    JuMP.set_optimizer(model, Ipopt.Optimizer)
+    JuMP.set_optimizer(model, () -> ComplementOpt.Optimizer(Ipopt.Optimizer()))
     # Need to set the bound relaxation explicitly to 0 for LiuFukushimaRelaxation
     JuMP.set_optimizer_attribute(model, "bound_relax_factor", 0.0)
     JuMP.set_optimizer_attribute(model, "bound_push", 1e-1)


### PR DESCRIPTION
I like this approach. We can reuse most of the logic of `AbstractBridgeOptimizer` and we can implement our reformulation as bridges which has the additional advantage that users could also just use `JuMP.add_bridge` to add our bridge to a JuMP model (but for that we'll have to complete the bridge implementation).
We'll have some reformulation that break the constraint-wise assumption so for these the user will need to use our `ComplementOpt.Optimizer` but it's nice that for the simple use cases that don't need that, we can just have classical bridges