### PR TITLE
Add slug to Codecov action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,5 @@ jobs:
       - uses: codecov/codecov-action@v6
         with:
           files: lcov.info
+          slug: jump-dev/MathOptComplements.jl
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov still thinks this is still `blegat/MathOptComplements.jl`